### PR TITLE
Issue 85 - Handles relative paths from command line args

### DIFF
--- a/src/Koffee/ProgramOptions.fs
+++ b/src/Koffee/ProgramOptions.fs
@@ -23,7 +23,7 @@ module ProgramOptions =
         let rec parse args options =
             match args with
             | Path path :: rest when options.StartPath.IsNone ->
-                parse rest { options with StartPath = Some path }
+                parse rest { options with StartPath = Some (path |> IOPath.GetFullPath) }
             | IntTuple "location" loc :: rest when options.StartLocation.IsNone ->
                 parse rest { options with StartLocation = Some loc }
             | IntTuple "size" loc :: rest when options.StartSize.IsNone ->


### PR DESCRIPTION
Previously invoking `koffee ./` in a directory would result in an error
and then proceed to open Koffee at the root. To remedy this, we simply
fetch the full path before getting the item