### PR TITLE
Feature: Remember sort per folder

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ### 0.6.0  Multi-select (WIP)
 - Changes UI to use new dark theme
 - Adds "Open File and Exit" command
+- #92 Adds per-folder storage of sort settings (Thanks @jilleJr)
 - Changes Escape key in path box to always switch focus back to item grid and reset path box to current location
 - Changes Tab key in path box to always move cursor to end
 - Changes path history limit from 200 to 500

--- a/src/Koffee.Tests/HistoryTests.fs
+++ b/src/Koffee.Tests/HistoryTests.fs
@@ -1,4 +1,4 @@
-﻿module Koffee.HistoryTests
+module Koffee.HistoryTests
 
 open NUnit.Framework
 open FsUnitTyped
@@ -73,10 +73,10 @@ let ``With same path in PathSort it overrides the existing`` () =
     resultSort |> shouldNotEqual sort
 
 [<Test>]
-let ``With ascending name sort it omits it`` () =
+let ``With default sort it omits it`` () =
     // Arrange
     let path = parseForTest "C:\Some\Path"
-    let sort = { Sort = SortField.Name; Descending = false }
+    let sort = PathSort.Default
     let history = History.Default
 
     // Act
@@ -87,17 +87,17 @@ let ``With ascending name sort it omits it`` () =
     pathsInHistory |> shouldNotContain path
 
 [<Test>]
-let ``With ascending name sort it removes the existing`` () =
+let ``With default sort it removes the existing`` () =
     // Arrange
     let path = parseForTest "C:\Some\Path"
-    let sort = { Sort = SortField.Modified; Descending = true }
+    let sort = { PathSort.Default with Descending = not PathSort.Default.Descending }
     let history = {
         History.Default with
             PathSort = Map.ofList [
                 (path, sort)
             ]
     }
-    let newSort = { Sort = SortField.Name; Descending = false }
+    let newSort = PathSort.Default
 
     // Act
     let result = history.WithPathSort path newSort

--- a/src/Koffee.Tests/HistoryTests.fs
+++ b/src/Koffee.Tests/HistoryTests.fs
@@ -1,0 +1,30 @@
+﻿module Koffee.HistoryTests
+
+open NUnit.Framework
+open FsUnitTyped
+open Newtonsoft.Json
+
+[<Test>]
+let ``History can be serialized and deserialized`` () =
+    let history =
+        { History.Default with
+            PathSort = Map.ofList [
+                (@"C:\Some\Path", {Sort = SortField.Name; Descending = true})
+                (@"C:\Some\Other\Path", {Sort = SortField.Modified; Descending = false})
+                (@"C:\Some\Third\Path", {Sort = SortField.Size; Descending = false})
+            ]
+            NetHosts = [
+                "Some net host"
+            ]
+            Paths = [
+                (Path.Parse "C:\Some\Path").Value
+            ]
+            Searches = [
+                ("downloads", false, false)
+                ("images", false, false)
+            ]
+        }
+    let converters = FSharpJsonConverters.getAll ()
+    let serialized = JsonConvert.SerializeObject(history, Formatting.Indented, converters)
+    let deserialized = JsonConvert.DeserializeObject<History>(serialized, converters)
+    deserialized |> shouldEqual history

--- a/src/Koffee.Tests/HistoryTests.fs
+++ b/src/Koffee.Tests/HistoryTests.fs
@@ -4,11 +4,6 @@ open NUnit.Framework
 open FsUnitTyped
 open Newtonsoft.Json
 
-let parseForTest pathStr =
-    match Path.Parse pathStr with
-    | Some p -> p
-    | None -> failwithf "Test path string '%s' does not parse" pathStr
-
 let seqSortPathsInHistory history =
     history.PathSort |> Map.toSeq |> Seq.map fst
 
@@ -17,15 +12,15 @@ let ``History can be serialized and deserialized`` () =
     let history =
         { History.Default with
             PathSort = Map.ofList [
-                (parseForTest @"C:\Some\Path", {Sort = SortField.Name; Descending = true})
-                (parseForTest @"C:\Some\Other\Path", {Sort = SortField.Modified; Descending = false})
-                (parseForTest @"C:\Some\Third\Path", {Sort = SortField.Size; Descending = false})
+                (createPath @"C:\Some\Path", {Sort = SortField.Name; Descending = true})
+                (createPath @"C:\Some\Other\Path", {Sort = SortField.Modified; Descending = false})
+                (createPath @"C:\Some\Third\Path", {Sort = SortField.Size; Descending = false})
             ]
             NetHosts = [
                 "Some net host"
             ]
             Paths = [
-                parseForTest "C:\Some\Path"
+                createPath "C:\Some\Path"
             ]
             Searches = [
                 ("downloads", false, false)
@@ -40,7 +35,7 @@ let ``History can be serialized and deserialized`` () =
 [<Test>]
 let ``With new PathSort it adds it to the list`` () =
     // Arrange
-    let path = parseForTest "C:\Some\Path"
+    let path = createPath "C:\Some\Path"
     let sort = { Sort = SortField.Modified; Descending = true }
     let history = {
         History.Default with
@@ -57,7 +52,7 @@ let ``With new PathSort it adds it to the list`` () =
 [<Test>]
 let ``With same path in PathSort it overrides the existing`` () =
     // Arrange
-    let path = parseForTest "C:\Some\Path"
+    let path = createPath "C:\Some\Path"
     let sort = { Sort = SortField.Modified; Descending = true }
     let history = {
         History.Default with
@@ -76,7 +71,7 @@ let ``With same path in PathSort it overrides the existing`` () =
 [<Test>]
 let ``With default sort it omits it`` () =
     // Arrange
-    let path = parseForTest "C:\Some\Path"
+    let path = createPath "C:\Some\Path"
     let sort = PathSort.Default
     let history = History.Default
 
@@ -90,7 +85,7 @@ let ``With default sort it omits it`` () =
 [<Test>]
 let ``With default sort it removes the existing`` () =
     // Arrange
-    let path = parseForTest "C:\Some\Path"
+    let path = createPath "C:\Some\Path"
     let sort = { PathSort.Default with Descending = not PathSort.Default.Descending }
     let history = {
         History.Default with
@@ -107,7 +102,7 @@ let ``With default sort it removes the existing`` () =
 
 let ``Get stored sort from find`` () =
     // Arrange
-    let path = parseForTest "C:\Some\Path"
+    let path = createPath "C:\Some\Path"
     let sort = { PathSort.Default with Descending = not PathSort.Default.Descending }
     let history = {
         History.Default with
@@ -122,7 +117,7 @@ let ``Get stored sort from find`` () =
 
 let ``Get default sort when none stored`` () =
     // Arrange
-    let path = parseForTest "C:\Some\Path"
+    let path = createPath "C:\Some\Path"
     let history = History.Default
 
     // Act

--- a/src/Koffee.Tests/HistoryTests.fs
+++ b/src/Koffee.Tests/HistoryTests.fs
@@ -28,3 +28,80 @@ let ``History can be serialized and deserialized`` () =
     let serialized = JsonConvert.SerializeObject(history, Formatting.Indented, converters)
     let deserialized = JsonConvert.DeserializeObject<History>(serialized, converters)
     deserialized |> shouldEqual history
+
+[<Test>]
+let ``With new PathSort it adds it to the list`` () =
+    // Arrange
+    let path = (Path.Parse "C:\Some\Path").Value
+    let pathKey = path.Format Windows
+    let sort = { Sort = SortField.Modified; Descending = true }
+    let history = {
+        History.Default with
+            PathSort = Map.empty
+    }
+
+    // Act
+    let result = history.WithPathSort path sort
+    let pathsInHistory = result.PathSort |> Map.toSeq |> Seq.map fst
+
+    // Assert
+    pathsInHistory |> shouldContain pathKey
+
+[<Test>]
+let ``With same path in PathSort it overrides the existing`` () =
+    // Arrange
+    let path = (Path.Parse "C:\Some\Path").Value
+    let pathKey = path.Format Windows
+    let sort = { Sort = SortField.Modified; Descending = true }
+    let history = {
+        History.Default with
+            PathSort = Map.ofList [
+                (pathKey, sort)
+            ]
+    }
+    let newSort = { Sort = SortField.Size; Descending = true }
+
+    // Act
+    let result = history.WithPathSort path newSort
+    let resultSort = result.PathSort.[pathKey]
+
+    // Assert
+    resultSort |> shouldEqual newSort
+    resultSort |> shouldNotEqual sort
+
+[<Test>]
+let ``With ascending name sort it omits it`` () =
+    // Arrange
+    let path = (Path.Parse "C:\Some\Path").Value
+    let pathKey = path.Format Windows
+    let sort = { Sort = SortField.Name; Descending = false }
+    let history = History.Default
+
+    // Act
+    let result = history.WithPathSort path sort
+    let pathsInHistory = result.PathSort |> Map.toSeq |> Seq.map fst
+
+    // Assert
+    pathsInHistory |> shouldNotContain pathKey
+
+[<Test>]
+let ``With ascending name sort it removes the existing`` () =
+    // Arrange
+    let path = (Path.Parse "C:\Some\Path").Value
+    let pathKey = path.Format Windows
+    let sort = { Sort = SortField.Modified; Descending = true }
+    let history = {
+        History.Default with
+            PathSort = Map.ofList [
+                (pathKey, sort)
+            ]
+    }
+    let newSort = { Sort = SortField.Name; Descending = false }
+
+    // Act
+    let result = history.WithPathSort path newSort
+    let pathsInHistory = result.PathSort |> Map.toSeq |> Seq.map fst
+
+    // Assert
+    pathsInHistory |> shouldNotContain pathKey
+

--- a/src/Koffee.Tests/Koffee.Tests.fsproj
+++ b/src/Koffee.Tests/Koffee.Tests.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="MainLogicTests_CreateRename.fs" />
     <Compile Include="MainLogicTests_Delete.fs" />
     <Compile Include="MainLogicTests_MoveCopy.fs" />
+    <Compile Include="NavTests_History.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Koffee\Koffee.fsproj" />

--- a/src/Koffee.Tests/Koffee.Tests.fsproj
+++ b/src/Koffee.Tests/Koffee.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="PathTests.fs" />
     <Compile Include="ProgramOptionsTests.fs" />
     <Compile Include="ConfigTests.fs" />
+    <Compile Include="HistoryTests.fs" />
     <Compile Include="MainLogicTests_InitModel.fs" />
     <Compile Include="MainLogicTests_OpenPath.fs" />
     <Compile Include="MainLogicTests_SuggestPaths.fs" />

--- a/src/Koffee.Tests/NavTests_History.fs
+++ b/src/Koffee.Tests/NavTests_History.fs
@@ -74,10 +74,6 @@ let createFs () =
         file "readme.md"
     ]
 
-let expectOk onError = function
-    | Error _ -> failwith onError
-    | Ok result -> result
-
 [<Test>]
 let ``Use stored sort on path change`` () =
     // Arrange
@@ -97,7 +93,7 @@ let ``Use stored sort on path change`` () =
     let result = Nav.openPath fs storedLocation SelectNone model
 
     // Assert
-    let resultModel = expectOk "Failed to open path" result
+    let resultModel = assertOk result
     resultModel.Sort |> shouldEqual (Some expected)
 
 [<Test>]
@@ -118,6 +114,6 @@ let ``Use default sort on path change when no stored sort`` () =
     let result = Nav.openPath fs newLocation SelectNone model
 
     // Assert
-    let resultModel = expectOk "Failed to open path" result
+    let resultModel = assertOk result
     resultModel.Sort |> shouldEqual (Some expected)
 

--- a/src/Koffee.Tests/NavTests_History.fs
+++ b/src/Koffee.Tests/NavTests_History.fs
@@ -15,7 +15,7 @@ let historyWithPathSort location sort =
     }
 
 [<Test>]
-let ``Sorting changes folders history`` () =
+let ``Sorting changes stored sort`` () =
     // Arrange
     let location = newPath "C:/Sample"
     let originalPathSort = { Sort = Modified; Descending = true }
@@ -34,7 +34,7 @@ let ``Sorting changes folders history`` () =
     resultSort |> shouldNotEqual (Some originalPathSort)
 
 [<Test>]
-let ``Sorting on different folder leaves it unchanged`` () =
+let ``Sorting on different folder leaves stored sort unchanged`` () =
     // Arrange
     let modelLocation = newPath "C:/Sample2"
     let pathSortLocation = newPath "C:/Sample1"

--- a/src/Koffee.Tests/NavTests_History.fs
+++ b/src/Koffee.Tests/NavTests_History.fs
@@ -22,9 +22,8 @@ let ``Sorting changes stored sort`` () =
     let model =
         { MainModel.Default with 
             Sort = Some (originalPathSort.Sort, originalPathSort.Descending)
-            Location = location
             History = historyWithPathSort location originalPathSort
-        }
+        }.WithLocation location
 
     // Act
     let resultModel = Nav.sortList Name model
@@ -42,9 +41,8 @@ let ``Sorting on different folder leaves stored sort unchanged`` () =
     let model =
         { MainModel.Default with 
             Sort = Some (originalPathSort.Sort, originalPathSort.Descending)
-            Location = modelLocation
             History = historyWithPathSort pathSortLocation originalPathSort
-        }
+        }.WithLocation modelLocation
 
     // Act
     let resultModel = Nav.sortList Name model
@@ -62,9 +60,8 @@ let ``Toggling sort into default removes it from history`` () =
     let model =
         { MainModel.Default with 
             Sort = Some (originalPathSort.Sort, originalPathSort.Descending)
-            Location = location
             History = historyWithPathSort location originalPathSort
-        }
+        }.WithLocation location
 
     // Act
     let resultModel = Nav.sortList PathSort.Default.Sort model
@@ -97,9 +94,8 @@ let ``Use stored sort on path change`` () =
     let model =
         { MainModel.Default with 
             Sort = Some (originalPathSort.Sort, originalPathSort.Descending)
-            Location = location
             History = historyWithPathSort storedLocation storedPathSort
-        }
+        }.WithLocation location
     let fs = createFs()
 
     // Act
@@ -119,9 +115,8 @@ let ``Use default sort on path change when no stored sort`` () =
     let model =
         { MainModel.Default with 
             Sort = Some (originalPathSort.Sort, originalPathSort.Descending)
-            Location = location
             History = History.Default
-        }
+        }.WithLocation location
     let fs = createFs()
 
     // Act

--- a/src/Koffee.Tests/NavTests_History.fs
+++ b/src/Koffee.Tests/NavTests_History.fs
@@ -4,11 +4,6 @@ open FsUnitTyped
 open Koffee.MainLogic
 open NUnit.Framework
 
-let newPath pathStr =
-    match Path.Parse pathStr with
-    | Some p -> p
-    | None -> failwithf "Test path string '%s' does not parse" pathStr
-
 let historyWithPathSort location sort =
     { History.Default with 
         PathSort = Map.empty |> Map.add location sort
@@ -17,7 +12,7 @@ let historyWithPathSort location sort =
 [<Test>]
 let ``Sorting changes stored sort`` () =
     // Arrange
-    let location = newPath "C:/Sample"
+    let location = createPath "C:/Sample"
     let originalPathSort = { Sort = Modified; Descending = true }
     let model =
         { MainModel.Default with 
@@ -35,8 +30,8 @@ let ``Sorting changes stored sort`` () =
 [<Test>]
 let ``Sorting on different folder leaves stored sort unchanged`` () =
     // Arrange
-    let modelLocation = newPath "C:/Sample2"
-    let pathSortLocation = newPath "C:/Sample1"
+    let modelLocation = createPath "C:/Sample2"
+    let pathSortLocation = createPath "C:/Sample1"
     let originalPathSort = { Sort = Modified; Descending = true }
     let model =
         { MainModel.Default with 
@@ -55,7 +50,7 @@ let ``Sorting on different folder leaves stored sort unchanged`` () =
 let ``Toggling sort into default removes it from history`` () =
     // Arrange
     let expected = None
-    let location = newPath "C:/Sample"
+    let location = createPath "C:/Sample"
     let originalPathSort = { PathSort.Default with Descending = not PathSort.Default.Descending }
     let model =
         { MainModel.Default with 
@@ -86,9 +81,9 @@ let expectOk onError = function
 [<Test>]
 let ``Use stored sort on path change`` () =
     // Arrange
-    let location = newPath "/c/"
+    let location = createPath "/c/"
     let originalPathSort = PathSort.Default
-    let storedLocation = newPath "/c/programs"
+    let storedLocation = createPath "/c/programs"
     let storedPathSort = { Sort = Modified; Descending = true }
     let expected = (storedPathSort.Sort, storedPathSort.Descending)
     let model =
@@ -109,8 +104,8 @@ let ``Use stored sort on path change`` () =
 let ``Use default sort on path change when no stored sort`` () =
     // Arrange
     let expected = (PathSort.Default.Sort, PathSort.Default.Descending)
-    let location = newPath "/c/"
-    let newLocation = newPath "/c/programs"
+    let location = createPath "/c/"
+    let newLocation = createPath "/c/programs"
     let originalPathSort = PathSort.Default
     let model =
         { MainModel.Default with 

--- a/src/Koffee.Tests/NavTests_History.fs
+++ b/src/Koffee.Tests/NavTests_History.fs
@@ -1,0 +1,133 @@
+module Koffee.NavTests_History
+
+open FsUnitTyped
+open Koffee.MainLogic
+open NUnit.Framework
+
+let newPath pathStr =
+    match Path.Parse pathStr with
+    | Some p -> p
+    | None -> failwithf "Test path string '%s' does not parse" pathStr
+
+let historyWithPathSort location sort =
+    { History.Default with 
+        PathSort = Map.empty |> Map.add location sort
+    }
+
+[<Test>]
+let ``Sorting changes folders history`` () =
+    // Arrange
+    let location = newPath "C:/Sample"
+    let originalPathSort = { Sort = Modified; Descending = true }
+    let model =
+        { MainModel.Default with 
+            Sort = Some (originalPathSort.Sort, originalPathSort.Descending)
+            Location = location
+            History = historyWithPathSort location originalPathSort
+        }
+
+    // Act
+    let resultModel = Nav.sortList Name model
+
+    // Assert
+    let resultSort = resultModel.History.PathSort.TryFind location
+    resultSort |> shouldNotEqual (Some originalPathSort)
+
+[<Test>]
+let ``Sorting on different folder leaves it unchanged`` () =
+    // Arrange
+    let modelLocation = newPath "C:/Sample2"
+    let pathSortLocation = newPath "C:/Sample1"
+    let originalPathSort = { Sort = Modified; Descending = true }
+    let model =
+        { MainModel.Default with 
+            Sort = Some (originalPathSort.Sort, originalPathSort.Descending)
+            Location = modelLocation
+            History = historyWithPathSort pathSortLocation originalPathSort
+        }
+
+    // Act
+    let resultModel = Nav.sortList Name model
+
+    // Assert
+    let resultSort = resultModel.History.PathSort.TryFind pathSortLocation
+    resultSort |> shouldEqual (Some originalPathSort)
+
+[<Test>]
+let ``Toggling sort into default removes it from history`` () =
+    // Arrange
+    let expected = None
+    let location = newPath "C:/Sample"
+    let originalPathSort = { PathSort.Default with Descending = not PathSort.Default.Descending }
+    let model =
+        { MainModel.Default with 
+            Sort = Some (originalPathSort.Sort, originalPathSort.Descending)
+            Location = location
+            History = historyWithPathSort location originalPathSort
+        }
+
+    // Act
+    let resultModel = Nav.sortList PathSort.Default.Sort model
+
+    // Assert
+    let resultSort = resultModel.History.PathSort.TryFind location
+    resultSort |> shouldEqual expected
+
+let createFs () =
+    FakeFileSystem [
+        folder "programs" [
+            file "koffee.exe"
+            file "notepad.exe"
+        ]
+        file "readme.md"
+    ]
+
+let expectOk onError = function
+    | Error _ -> failwith onError
+    | Ok result -> result
+
+[<Test>]
+let ``Use stored sort on path change`` () =
+    // Arrange
+    let location = newPath "/c/"
+    let originalPathSort = PathSort.Default
+    let storedLocation = newPath "/c/programs"
+    let storedPathSort = { Sort = Modified; Descending = true }
+    let expected = (storedPathSort.Sort, storedPathSort.Descending)
+    let model =
+        { MainModel.Default with 
+            Sort = Some (originalPathSort.Sort, originalPathSort.Descending)
+            Location = location
+            History = historyWithPathSort storedLocation storedPathSort
+        }
+    let fs = createFs()
+
+    // Act
+    let result = Nav.openPath fs storedLocation SelectNone model
+
+    // Assert
+    let resultModel = expectOk "Failed to open path" result
+    resultModel.Sort |> shouldEqual (Some expected)
+
+[<Test>]
+let ``Use default sort on path change when no stored sort`` () =
+    // Arrange
+    let expected = (PathSort.Default.Sort, PathSort.Default.Descending)
+    let location = newPath "/c/"
+    let newLocation = newPath "/c/programs"
+    let originalPathSort = PathSort.Default
+    let model =
+        { MainModel.Default with 
+            Sort = Some (originalPathSort.Sort, originalPathSort.Descending)
+            Location = location
+            History = History.Default
+        }
+    let fs = createFs()
+
+    // Act
+    let result = Nav.openPath fs newLocation SelectNone model
+
+    // Assert
+    let resultModel = expectOk "Failed to open path" result
+    resultModel.Sort |> shouldEqual (Some expected)
+

--- a/src/Koffee.Tests/PathTests.fs
+++ b/src/Koffee.Tests/PathTests.fs
@@ -3,6 +3,7 @@
 open NUnit.Framework
 open FsUnitTyped
 open System.Reflection
+open System
 
 let getPathValue (path: Path) =
     typedefof<Path>.GetProperty("Value", BindingFlags.NonPublic ||| BindingFlags.Instance)
@@ -118,3 +119,31 @@ let ``Parent returns expected value`` pathStr expected =
 [<TestCase(@"\\server\share", "/net/server/share")>]
 let ``Format drive in Unix`` pathStr expected =
     (parseForTest pathStr).Format Unix |> shouldEqual expected
+
+[<TestCase(@"C:\Sample", @"C:\Sample", 0)>]
+[<TestCase(@"C:\Sample1", @"C:\Sample2", -1)>]
+[<TestCase(@"C:\Sample2", @"C:\Sample1", 1)>]
+let ``Compare Windows paths`` aPath bPath expected =
+    let aComp = parseForTest aPath :> IComparable
+    let bComp = parseForTest bPath :> IComparable
+    aComp.CompareTo bComp |> shouldEqual expected
+    bComp.CompareTo aComp |> shouldEqual -expected
+
+[<TestCase(@"/c/Sample", @"/c/Sample", 0)>]
+[<TestCase(@"/c/Sample1", @"/c/Sample2", -1)>]
+[<TestCase(@"/c/Sample2", @"/c/Sample1", 1)>]
+let ``Compare Unix paths`` aPath bPath expected =
+    let aComp = parseForTest aPath :> IComparable
+    let bComp = parseForTest bPath :> IComparable
+    aComp.CompareTo bComp |> shouldEqual expected
+    bComp.CompareTo aComp |> shouldEqual -expected
+
+[<TestCase(@"C:/Sample", @"/c/Sample", 0)>]
+[<TestCase(@"C:/Sample1", @"/c/Sample2", -1)>]
+[<TestCase(@"C:/Sample2", @"/c/Sample1", 1)>]
+let ``Compare Windows and Unix paths`` aPath bPath expected =
+    let aComp = parseForTest aPath :> IComparable
+    let bComp = parseForTest bPath :> IComparable
+    aComp.CompareTo bComp |> shouldEqual expected
+    bComp.CompareTo aComp |> shouldEqual -expected
+

--- a/src/Koffee.Tests/PathTests.fs
+++ b/src/Koffee.Tests/PathTests.fs
@@ -137,30 +137,27 @@ let ``TypeConverter from string`` () =
     :?> Path
     |> shouldEqual expected
 
-[<TestCase(@"C:\Sample", @"C:\Sample", 0)>]
-[<TestCase(@"C:\Sample1", @"C:\Sample2", -1)>]
-[<TestCase(@"C:\Sample2", @"C:\Sample1", 1)>]
-let ``Compare Windows paths`` aPath bPath expected =
+let testComparability aPath bPath expected =
     let aComp = parseForTest aPath :> IComparable
     let bComp = parseForTest bPath :> IComparable
     aComp.CompareTo bComp |> shouldEqual expected
     bComp.CompareTo aComp |> shouldEqual -expected
+
+[<TestCase(@"C:\Sample", @"C:\Sample", 0)>]
+[<TestCase(@"C:\Sample1", @"C:\Sample2", -1)>]
+[<TestCase(@"C:\Sample2", @"C:\Sample1", 1)>]
+let ``Compare Windows paths`` aPath bPath expected =
+    testComparability aPath bPath expected
 
 [<TestCase(@"/c/Sample", @"/c/Sample", 0)>]
 [<TestCase(@"/c/Sample1", @"/c/Sample2", -1)>]
 [<TestCase(@"/c/Sample2", @"/c/Sample1", 1)>]
 let ``Compare Unix paths`` aPath bPath expected =
-    let aComp = parseForTest aPath :> IComparable
-    let bComp = parseForTest bPath :> IComparable
-    aComp.CompareTo bComp |> shouldEqual expected
-    bComp.CompareTo aComp |> shouldEqual -expected
+    testComparability aPath bPath expected
 
 [<TestCase(@"C:/Sample", @"/c/Sample", 0)>]
 [<TestCase(@"C:/Sample1", @"/c/Sample2", -1)>]
 [<TestCase(@"C:/Sample2", @"/c/Sample1", 1)>]
 let ``Compare Windows and Unix paths`` aPath bPath expected =
-    let aComp = parseForTest aPath :> IComparable
-    let bComp = parseForTest bPath :> IComparable
-    aComp.CompareTo bComp |> shouldEqual expected
-    bComp.CompareTo aComp |> shouldEqual -expected
+    testComparability aPath bPath expected
 

--- a/src/Koffee.Tests/PathTests.fs
+++ b/src/Koffee.Tests/PathTests.fs
@@ -137,27 +137,11 @@ let ``TypeConverter from string`` () =
     :?> Path
     |> shouldEqual expected
 
-let testComparability aPath bPath expected =
+[<TestCase(@"C:\Sample", @"C:\Sample", 0)>]
+[<TestCase(@"C:\SAMPLE", @"C:\sample", 0)>]
+[<TestCase(@"C:\Sample2", @"C:\Sample1", 1)>]
+let ``Compare Windows paths`` aPath bPath expected =
     let aComp = parseForTest aPath :> IComparable
     let bComp = parseForTest bPath :> IComparable
     aComp.CompareTo bComp |> shouldEqual expected
     bComp.CompareTo aComp |> shouldEqual -expected
-
-[<TestCase(@"C:\Sample", @"C:\Sample", 0)>]
-[<TestCase(@"C:\Sample2", @"C:\Sample1", 1)>]
-[<TestCase(@"C:\SAMPLE", @"C:\sample", 0)>]
-let ``Compare Windows paths`` aPath bPath expected =
-    testComparability aPath bPath expected
-
-[<TestCase(@"/c/Sample", @"/c/Sample", 0)>]
-[<TestCase(@"/c/Sample2", @"/c/Sample1", 1)>]
-[<TestCase(@"/c/SAMPLE", @"/c/sample", 0)>]
-let ``Compare Unix paths`` aPath bPath expected =
-    testComparability aPath bPath expected
-
-[<TestCase(@"C:/Sample", @"/c/Sample", 0)>]
-[<TestCase(@"C:/Sample2", @"/c/Sample1", 1)>]
-[<TestCase(@"C:/SAMPLE", @"/c/sample", 0)>]
-let ``Compare Windows and Unix paths`` aPath bPath expected =
-    testComparability aPath bPath expected
-

--- a/src/Koffee.Tests/PathTests.fs
+++ b/src/Koffee.Tests/PathTests.fs
@@ -120,6 +120,23 @@ let ``Parent returns expected value`` pathStr expected =
 let ``Format drive in Unix`` pathStr expected =
     (parseForTest pathStr).Format Unix |> shouldEqual expected
 
+[<Test>]
+let ``TypeConverter to string`` () =
+    let conv = System.ComponentModel.TypeDescriptor.GetConverter typeof<Path>
+    let pathString = @"C:\Sample"
+    parseForTest pathString
+    |> conv.ConvertToString
+    |> shouldEqual pathString
+    
+[<Test>]
+let ``TypeConverter from string`` () =
+    let conv = System.ComponentModel.TypeDescriptor.GetConverter typeof<Path>
+    let pathString = @"C:\Sample"
+    let expected = parseForTest pathString
+    conv.ConvertFromString pathString
+    :?> Path
+    |> shouldEqual expected
+
 [<TestCase(@"C:\Sample", @"C:\Sample", 0)>]
 [<TestCase(@"C:\Sample1", @"C:\Sample2", -1)>]
 [<TestCase(@"C:\Sample2", @"C:\Sample1", 1)>]

--- a/src/Koffee.Tests/PathTests.fs
+++ b/src/Koffee.Tests/PathTests.fs
@@ -1,4 +1,4 @@
-﻿module Koffee.PathTests
+module Koffee.PathTests
 
 open NUnit.Framework
 open FsUnitTyped
@@ -144,20 +144,20 @@ let testComparability aPath bPath expected =
     bComp.CompareTo aComp |> shouldEqual -expected
 
 [<TestCase(@"C:\Sample", @"C:\Sample", 0)>]
-[<TestCase(@"C:\Sample1", @"C:\Sample2", -1)>]
 [<TestCase(@"C:\Sample2", @"C:\Sample1", 1)>]
+[<TestCase(@"C:\SAMPLE", @"C:\sample", 0)>]
 let ``Compare Windows paths`` aPath bPath expected =
     testComparability aPath bPath expected
 
 [<TestCase(@"/c/Sample", @"/c/Sample", 0)>]
-[<TestCase(@"/c/Sample1", @"/c/Sample2", -1)>]
 [<TestCase(@"/c/Sample2", @"/c/Sample1", 1)>]
+[<TestCase(@"/c/SAMPLE", @"/c/sample", 0)>]
 let ``Compare Unix paths`` aPath bPath expected =
     testComparability aPath bPath expected
 
 [<TestCase(@"C:/Sample", @"/c/Sample", 0)>]
-[<TestCase(@"C:/Sample1", @"/c/Sample2", -1)>]
 [<TestCase(@"C:/Sample2", @"/c/Sample1", 1)>]
+[<TestCase(@"C:/SAMPLE", @"/c/sample", 0)>]
 let ``Compare Windows and Unix paths`` aPath bPath expected =
     testComparability aPath bPath expected
 

--- a/src/Koffee/MainController.fs
+++ b/src/Koffee/MainController.fs
@@ -205,6 +205,7 @@ module Nav =
             Sort = Some (field, desc)
             Items = model.Items |> SortField.SortByTypeThen (field, desc)
             Status = Some <| MainStatus.sort field desc
+            History = model.History.WithPathSort model.Location { Sort = field; Descending = desc }
         } |> select selectType
 
     let toggleHidden fsReader (model: MainModel) = asyncSeqResult {

--- a/src/Koffee/MainController.fs
+++ b/src/Koffee/MainController.fs
@@ -99,6 +99,7 @@ module Nav =
                 Directory = directory
                 History = history
                 Status = None
+                Sort = Some (history.FindSortOrDefault path |> PathSort.toTuple)
             } |> clearSearchProps
               |> listDirectory select
     }

--- a/src/Koffee/MainController.fs
+++ b/src/Koffee/MainController.fs
@@ -84,6 +84,7 @@ module Nav =
                 History = model.History.WithPathAndNetHost path
                 Status = None
                 Sort = Some (model.History.FindSortOrDefault path |> PathSort.toTuple)
+                Cursor = 0
             } |> clearSearchProps
               |> listDirectory select
     }

--- a/src/Koffee/MainController.fs
+++ b/src/Koffee/MainController.fs
@@ -53,12 +53,6 @@ let private itemsInDirOrNetHost (fsReader: IFileSystemReader) path history =
     else
         fsReader.GetItems path |> actionError "open path"
 
-let private historyWithPathAndItsNetHost (history: History) path =
-    let hist = history.WithPath path
-    match path.NetHost with
-    | Some host -> hist.WithNetHost host
-    | None -> hist
-
 let private withBackStackedLocation model path =
     if path <> model.Location then
         { model.WithLocation path with

--- a/src/Koffee/MainModel.fs
+++ b/src/Koffee/MainModel.fs
@@ -216,7 +216,7 @@ type History = {
     Paths: Path list
     Searches: (string * bool * bool) list
     NetHosts: string list
-    PathSort: Map<string, PathSort>
+    PathSort: Map<Path, PathSort>
 }
 with
     static member private pushDistinct max list item =
@@ -240,12 +240,11 @@ with
     static member private omitPathSortFromHistory sort =
         sort.Sort = Name && not sort.Descending
 
-    member this.WithPathSort (path: Path) sort =
-        let key = path.Format Windows
+    member this.WithPathSort path sort =
         if History.omitPathSortFromHistory sort then
-            { this with PathSort = this.PathSort.Remove key }
+            { this with PathSort = this.PathSort.Remove path }
         else
-            { this with PathSort = this.PathSort.Add(key, sort) }
+            { this with PathSort = this.PathSort.Add(path, sort) }
 
     static member MaxPaths = 500
     static member MaxSearches = 50

--- a/src/Koffee/MainModel.fs
+++ b/src/Koffee/MainModel.fs
@@ -237,8 +237,15 @@ with
     member this.WithoutNetHost host =
         { this with NetHosts = this.NetHosts |> List.filter (not << String.equalsIgnoreCase host) }
 
-    member this.WithPathSort (path: Path) (sort: PathSort) =
-        this
+    static member private omitPathSortFromHistory sort =
+        sort.Sort = Name && not sort.Descending
+
+    member this.WithPathSort (path: Path) sort =
+        let key = path.Format Windows
+        if History.omitPathSortFromHistory sort then
+            { this with PathSort = this.PathSort.Remove key }
+        else
+            { this with PathSort = this.PathSort.Add(key, sort) }
 
     static member MaxPaths = 500
     static member MaxSearches = 50

--- a/src/Koffee/MainModel.fs
+++ b/src/Koffee/MainModel.fs
@@ -246,6 +246,13 @@ with
     member this.WithoutNetHost host =
         { this with NetHosts = this.NetHosts |> List.filter (not << String.equalsIgnoreCase host) }
 
+    member this.WithPathAndNetHost path =
+        let hist = this.WithPath path
+        match path.NetHost with
+        | Some host -> hist.WithNetHost host
+        | None -> hist
+
+
     static member private omitPathSortFromHistory sort =
         sort = PathSort.Default
 

--- a/src/Koffee/MainModel.fs
+++ b/src/Koffee/MainModel.fs
@@ -206,10 +206,17 @@ with
         Bookmarks = []
     }
 
+[<Struct>]
+type PathSort = {
+    Sort: SortField
+    Descending: bool
+}
+
 type History = {
     Paths: Path list
     Searches: (string * bool * bool) list
     NetHosts: string list
+    PathSort: Map<string, PathSort>
 }
 with
     static member private pushDistinct max list item =
@@ -237,6 +244,7 @@ with
         Paths = []
         Searches = []
         NetHosts = []
+        PathSort = Map.empty
     }
 
 type CancelToken() =

--- a/src/Koffee/MainModel.fs
+++ b/src/Koffee/MainModel.fs
@@ -344,6 +344,15 @@ type MainModel = {
 
     member this.WithCursorRel move = this.WithCursor (this.Cursor + move)
 
+    member this.WithBackStackedLocation path =
+        if path <> this.Location then
+            { this.WithLocation path with
+                BackStack = (this.Location, this.Cursor) :: this.BackStack
+                ForwardStack = []
+                Cursor = 0
+            }
+        else this
+
     static member Default = {
         Location = Path.Root
         LocationInput = Path.Root.Format Windows

--- a/src/Koffee/MainModel.fs
+++ b/src/Koffee/MainModel.fs
@@ -214,6 +214,13 @@ type PathSort = {
 with
     static member Default = { Sort = Name; Descending = false }
 
+    static member ofTuple (sort, descending) = {
+        Sort = sort
+        Descending = descending
+    }
+
+    static member toTuple sort = (sort.Sort, sort.Descending)
+
 type History = {
     Paths: Path list
     Searches: (string * bool * bool) list
@@ -247,6 +254,11 @@ with
             { this with PathSort = this.PathSort.Remove path }
         else
             { this with PathSort = this.PathSort.Add(path, sort) }
+
+    member this.FindSortOrDefault path =
+        match this.PathSort.TryFind path with
+        | Some sort -> sort
+        | None -> PathSort.Default
 
     static member MaxPaths = 500
     static member MaxSearches = 50

--- a/src/Koffee/MainModel.fs
+++ b/src/Koffee/MainModel.fs
@@ -349,7 +349,6 @@ type MainModel = {
             { this.WithLocation path with
                 BackStack = (this.Location, this.Cursor) :: this.BackStack
                 ForwardStack = []
-                Cursor = 0
             }
         else this
 

--- a/src/Koffee/MainModel.fs
+++ b/src/Koffee/MainModel.fs
@@ -1,4 +1,4 @@
-﻿namespace Koffee
+namespace Koffee
 
 open System
 open System.Windows.Input
@@ -211,6 +211,8 @@ type PathSort = {
     Sort: SortField
     Descending: bool
 }
+with
+    static member Default = { Sort = Name; Descending = false }
 
 type History = {
     Paths: Path list
@@ -238,7 +240,7 @@ with
         { this with NetHosts = this.NetHosts |> List.filter (not << String.equalsIgnoreCase host) }
 
     static member private omitPathSortFromHistory sort =
-        sort.Sort = Name && not sort.Descending
+        sort = PathSort.Default
 
     member this.WithPathSort path sort =
         if History.omitPathSortFromHistory sort then

--- a/src/Koffee/MainModel.fs
+++ b/src/Koffee/MainModel.fs
@@ -237,6 +237,9 @@ with
     member this.WithoutNetHost host =
         { this with NetHosts = this.NetHosts |> List.filter (not << String.equalsIgnoreCase host) }
 
+    member this.WithPathSort (path: Path) (sort: PathSort) =
+        this
+
     static member MaxPaths = 500
     static member MaxSearches = 50
 

--- a/src/Koffee/Path.fs
+++ b/src/Koffee/Path.fs
@@ -1,6 +1,7 @@
 ﻿namespace Koffee
 
 open System
+open System.ComponentModel
 open System.Text.RegularExpressions
 open Acadian.FSharp
 
@@ -15,6 +16,7 @@ type PathFormat =
         | Windows -> @"\"
         | Unix -> "/"
 
+[<TypeConverter(typeof<PathToStringTypeConverter>)>]
 type Path private (path: string) =
     static let root = ""
     static let rootWindows = "Drives"
@@ -164,3 +166,20 @@ type Path private (path: string) =
 
     // for debugging
     override this.ToString() = this.Format Windows
+
+// allows using Path as Map/dictionary key in Json.NET
+and private PathToStringTypeConverter() =
+    inherit TypeConverter()
+    override _.CanConvertFrom (_, typ) = typ = typeof<string>
+    override _.CanConvertTo (_, typ) = typ = typeof<string>
+
+    override _.ConvertTo(context, culture, value, destinationType) =
+        if destinationType = typeof<string> then
+            (value :?> Path).Format Windows |> box
+        else
+            base.ConvertTo(context, culture, value, destinationType)
+
+    override _.ConvertFrom(context, culture, value) =
+        match value with
+        | :? string as stringValue -> stringValue |> Path.Parse |> Option.get |> box
+        | _ -> base.ConvertFrom(context, culture, value)

--- a/src/Koffee/Path.fs
+++ b/src/Koffee/Path.fs
@@ -149,6 +149,12 @@ type Path private (path: string) =
     member this.IsNetHost =
         this.IsNetPath && path.Length > 2 && not (path.Substring(2).Contains(@"\"))
 
+    interface IComparable with
+        member this.CompareTo other =
+            match other with
+            | :? Path as p -> this.Value.CompareTo p.Value
+            | _ -> 0
+
     override this.Equals other =
         match other with
         | :? Path as p -> this.Value |> String.equalsIgnoreCase p.Value

--- a/src/Koffee/Path.fs
+++ b/src/Koffee/Path.fs
@@ -167,7 +167,7 @@ type Path private (path: string) =
     // for debugging
     override this.ToString() = this.Format Windows
 
-// allows using Path as Map/dictionary key in Json.NET
+// allows using Path as the key of Map/dictionary in Json.NET
 and private PathToStringTypeConverter() =
     inherit TypeConverter()
     override _.CanConvertFrom (_, typ) = typ = typeof<string>

--- a/src/Koffee/Path.fs
+++ b/src/Koffee/Path.fs
@@ -1,4 +1,4 @@
-﻿namespace Koffee
+namespace Koffee
 
 open System
 open System.ComponentModel
@@ -154,12 +154,12 @@ type Path private (path: string) =
     interface IComparable with
         member this.CompareTo other =
             match other with
-            | :? Path as p -> this.Value.CompareTo p.Value
+            | :? Path as p -> (this.Format Windows).CompareTo (p.Format Windows)
             | _ -> 0
 
     override this.Equals other =
         match other with
-        | :? Path as p -> this.Value |> String.equalsIgnoreCase p.Value
+        | :? Path as p -> this.Format Windows |> String.equalsIgnoreCase (p.Format Windows)
         | _ -> false
 
     override this.GetHashCode() = this.Value.ToLower().GetHashCode()

--- a/src/Koffee/Path.fs
+++ b/src/Koffee/Path.fs
@@ -85,8 +85,6 @@ type Path private (path: string) =
 
     member private this.Value = path
 
-    member private this.Normalized = this.Format Windows
-
     member this.Format fmt =
         match fmt with
         | Windows ->
@@ -157,15 +155,15 @@ type Path private (path: string) =
     interface IComparable with
         member this.CompareTo other =
             match other with
-            | :? Path as p -> String.Compare(this.Normalized, p.Normalized, true)
+            | :? Path as p -> String.Compare(this.Value, p.Value, ignoreCase=true)
             | _ -> 0
 
     override this.Equals other =
         match other with
-        | :? Path as p -> this.Normalized |> String.equalsIgnoreCase p.Normalized
+        | :? Path as p -> this.Value |> String.equalsIgnoreCase p.Value
         | _ -> false
 
-    override this.GetHashCode() = this.Normalized.ToLower().GetHashCode()
+    override this.GetHashCode() = this.Value.ToLower().GetHashCode()
 
     // for debugging
     override this.ToString() = this.Format Windows

--- a/src/Koffee/Path.fs
+++ b/src/Koffee/Path.fs
@@ -165,7 +165,7 @@ type Path private (path: string) =
         | :? Path as p -> this.Normalized |> String.equalsIgnoreCase p.Normalized
         | _ -> false
 
-    override this.GetHashCode() = this.Normalized.GetHashCode()
+    override this.GetHashCode() = this.Normalized.ToLower().GetHashCode()
 
     // for debugging
     override this.ToString() = this.Format Windows

--- a/src/Koffee/Path.fs
+++ b/src/Koffee/Path.fs
@@ -85,6 +85,8 @@ type Path private (path: string) =
 
     member private this.Value = path
 
+    member private this.Normalized = this.Format Windows
+
     member this.Format fmt =
         match fmt with
         | Windows ->
@@ -151,18 +153,19 @@ type Path private (path: string) =
     member this.IsNetHost =
         this.IsNetPath && path.Length > 2 && not (path.Substring(2).Contains(@"\"))
 
+    // needed to use Path as Map key
     interface IComparable with
         member this.CompareTo other =
             match other with
-            | :? Path as p -> (this.Format Windows).CompareTo (p.Format Windows)
+            | :? Path as p -> String.Compare(this.Normalized, p.Normalized, true)
             | _ -> 0
 
     override this.Equals other =
         match other with
-        | :? Path as p -> this.Format Windows |> String.equalsIgnoreCase (p.Format Windows)
+        | :? Path as p -> this.Normalized |> String.equalsIgnoreCase p.Normalized
         | _ -> false
 
-    override this.GetHashCode() = this.Value.ToLower().GetHashCode()
+    override this.GetHashCode() = this.Normalized.GetHashCode()
 
     // for debugging
     override this.ToString() = this.Format Windows


### PR DESCRIPTION
Now it remembers the sorting per folder.

What it accomplishes:

- [x] Each folder has separate sorting
- [x] Only saves new sortings when `sort != (Name, false)`
- [x] Removes old sortings from save file when `sort = (Name, false)`
- [x] Tests to confirm this behaviour

I took some liberties in developing this and went a little out-of-spec. Fully OK to reject some of my ideas, and I'll revert them ASAP. The main differences are:

- Added a new type `PathSort` to represent a folders sorting. I did not replace the existing uses of `(SortField, bool)` tuples, but that might be something to consider for consistency (and more type-safety). I really dislike having unnamed fields, such as the unnamed bool.

- Stores the sort in a `Map<Path, PathSort>` instead of a `(Path, SortField, bool) list`. Mainly for improved search abilities, and the JSON looks nicer :)

- Added code to `Path` to make it serializable as dictionary keys and compatible with using as keys in `Map<'K, 'V>`'s

- Refactored a little in `MainController.fs`. Thought it was a little difficult to understand some of the code so I extracted some snippets into dedicated functions. Tried to keep my changes scoped to this PR but some code I couldn't refuse to touch.

## Preview

![koffee-save-sort](https://user-images.githubusercontent.com/2477952/96183343-08315200-0f37-11eb-93e8-fa60120b626c.gif)

The history.json file from the GIF above ends like this:

```json
  "PathSort": {
    "C:\\Users\\kalle": {
      "Sort": "Size",
      "Descending": true
    },
    "C:\\Users\\kalle\\Documents": {
      "Sort": "Modified",
      "Descending": true
    },
    "C:\\Users\\kalle\\Documents\\Programs": {
      "Sort": "Name",
      "Descending": true
    }
  }
}
```

This was an experience! It was fun to code more officially in F#. Still a big noob in when it comes to common F# practices and thinking habits. Will probably look into other issues on your repo here :)

---

Closes #63 