### PR TITLE
Sets up an extremely half baked icon fetching/rendering pipeline

### DIFF
--- a/src/Koffee/MainModel.fs
+++ b/src/Koffee/MainModel.fs
@@ -2,7 +2,10 @@
 
 open System
 open System.Windows
+open System.Windows.Controls
 open System.Windows.Input
+open System.Windows.Media
+open System.Windows.Media.Imaging
 open Acadian.FSharp
 
 type ItemType =
@@ -55,6 +58,19 @@ with
     member this.TypeName = this.Type.ToString()
 
     member this.SizeFormatted = this.Size |> Option.map Format.fileSize |? ""
+        
+    member this.Image =
+        match this.Type with
+        | File -> 
+            let x = System.Drawing.Icon.ExtractAssociatedIcon(this.Path.ToString())
+            System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(
+                x.ToBitmap().GetHbitmap(),
+                IntPtr.Zero,
+                Int32Rect.Empty,
+                System.Windows.Media.Imaging.BitmapSizeOptions.FromEmptyOptions())
+        | _ ->
+            null
+            
 
     static member Empty =
         { Path = Path.Root; Name = ""; Type = Empty

--- a/src/Koffee/MainView.fs
+++ b/src/Koffee/MainView.fs
@@ -105,7 +105,7 @@ module MainView =
 
         // setup grid
         let mutable relativePathFormat = string
-        window.ItemGrid.AddColumn(<@ fun (i: Item) -> i.Type @>, "", conversion = (fun t -> t.Symbol))
+        window.ItemGrid.AddImageColumn(<@ fun (i: Item) -> i.Image @>)
         window.ItemGrid.AddColumn(<@ fun (i: Item) -> i.Name @>, widthWeight = 1.0)
         window.ItemGrid.AddColumn(<@ fun (i: Item) -> i.Path @>, "Relative Path", widthWeight = 1.0,
                                   conversion = (fun p -> p.Parent |> relativePathFormat))

--- a/src/Koffee/UIHelpers.fs
+++ b/src/Koffee/UIHelpers.fs
@@ -7,6 +7,7 @@ open System.Windows.Data
 open System.Windows.Controls
 open System.Windows.Input
 open System.Reactive.Linq
+open System.Windows.Media.Imaging
 open Microsoft.FSharp.Quotations
 open Acadian.FSharp
 
@@ -89,6 +90,29 @@ type DataGrid with
         )
         format |> Option.iter binding.set_StringFormat
         col.Binding <- binding
+
+        this.Columns.Add col
+        
+    member this.AddImageColumn (projection: Expr<'a -> BitmapSource>, ?widthWeight) =
+        let propName =
+            match projection with
+            | Reflection.PropertySelector prop -> prop.Name
+            | _ -> failwith "Projection expression must be a function that returns a property from an item."
+        let col = DataGridTemplateColumn()
+        col.Header <- ""
+        
+        let factory = FrameworkElementFactory(typeof<Image>)
+
+        let binding = Binding(propName)
+        
+        let cellTemplate = DataTemplate()
+        cellTemplate.VisualTree <- factory
+        factory.SetValue(Image.SourceProperty, binding)
+        
+        col.CellTemplate <- cellTemplate
+        
+        let widthType = if widthWeight.IsSome then DataGridLengthUnitType.Star else DataGridLengthUnitType.Auto
+        col.Width <- DataGridLength(widthWeight |? 1.0, widthType)
 
         this.Columns.Add col
 


### PR DESCRIPTION
Hey Matt, here's a very much not ready changeset to add icons. I noticed that I created #3 way back when, but, you know, gotta be the change you want to see in the world. There's a lot of things wrong with this changeset. For example, I'm fairly sure that after using CreateBitmapSourceFromHBitmap, you are responsible for deleting the resource assosciated with the nativeint generated by GetHbitmap(). This requires a native dll import. Obviously, that only works on windows (booo). Anyways, here's what the result looks like:

![image](https://user-images.githubusercontent.com/1749998/190309848-b58b3d6b-66ec-4063-8d2a-ff16192b0107.png)
